### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,11 @@ git clone https://github.com/smartcontractkit/apeworx-starter-kit
 cd apeworx-starter-kit
 ape plugins install alchemy vyper
 ```
-
-2. You're ready to go!
+2. Install Foundry network provider plugin for Ape.
+```
+pip install ape-foundry
+```
+3. You're ready to go!
 
 
 Run tests:


### PR DESCRIPTION
Maybe you forget a step in Quickstart section to install "pip install ape-foundry" ?
I received this warning before installing it "WARNING: unprocessed plugin config(s): foundry. plugins may not be installed yet or keys may be mis-spelled."