### PR TITLE
Patch VRFCoordinatorV2Mock fulfillRandomWords raw_call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 venv
 .build
+__pycache__

--- a/contracts/test/VRFCoordinatorV2Mock.vy
+++ b/contracts/test/VRFCoordinatorV2Mock.vy
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 # @version ^0.3.4
 
+MAX_ARRAY_SIZE: constant(uint256) = 10
+
 BASE_FEE: immutable(uint96)
 GAS_PRICE_LINK: immutable(uint96)
 
@@ -41,20 +43,20 @@ def fulfillRandomWords(requestId: uint256, consumer: address):
         consumer (address): The consumer address to 
     """    
     # Default to 77 as a mocking example
-    words: uint256[1] = [77]
+    words: DynArray[uint256, MAX_ARRAY_SIZE] = [77]
     self.fulfillRandomWordsWithOverride(requestId, consumer, words)
 
 
 @internal
-def fulfillRandomWordsWithOverride(requestId: uint256, consumer: address, words: uint256[1]):
+def fulfillRandomWordsWithOverride(requestId: uint256, consumer: address, words: DynArray[uint256, MAX_ARRAY_SIZE]):
     """Returns an array of random numbers. In this mock contract, we ignore the requestId and consumer. 
 
     Args:
         requestId (uint256): The request Id number
         consumer (address): The consumer address to 
-        words (uint256[1]): The array of random numbers, we are defaulting to 1 for vyper
+        words (DynArray[uint256, MAX_ARRAY_SIZE]): The array of random numbers, we are defaulting to MAX_ARRAY_SIZE for vyper
     """    
-    call_data: Bytes[3236] = _abi_encode(requestId, words, method_id=method_id("rawFulfillRandomWords(uint256,uint256[1])"))
+    call_data: Bytes[3236] = _abi_encode(requestId, words, method_id=method_id("rawFulfillRandomWords(uint256,uint256[])"))
     response: Bytes[32] = raw_call(consumer, call_data, max_outsize=32)
     log RandomWordsFulfilled(requestId, requestId, 0, True)
 


### PR DESCRIPTION
Hey Patrick,

After testing your repository I realize that your test of the VRFCoordinator also failed due to the `fulfillRandomWords` which cannot match the signature of your `rawFulfillRandomWords` from your VRFConsumerV2 contract (see my issue #7).

I found that the solution was to replace the type of the "words" variable by a dynamic array instead of fixed array and also change the method_id by `rawFulfillRandomWords(uint256,uint256[])` and then the signatures can match.

Now the tests runs without issues.
Feel free to check by yourself.